### PR TITLE
Update middleware version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,6 +34,8 @@ jobs:
           push: false
           build-args: |
             TOOLCHAIN=${{ env.RUST_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build container image
         uses: docker/build-push-action@v5
@@ -44,3 +46,5 @@ jobs:
             ghcr.io/${{ github.repository }}/rust-musl-builder:${{ env.RUST_VERSION }}-llvm-cov
           build-args: |
             TOOLCHAIN=${{ env.RUST_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,9 +18,9 @@ jobs:
         with:
           fetch-depth: 1
 
-      # - name: Branch name
-      #   id: branch_name
-      #   run: echo "TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Github Docker Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,6 @@
 name: Docker Image CI
 
-on:
-  release:
-    types: [published]
+on: [push]
 
 env:
   RUST_VERSION: 1.76.0 # renovate: depName=rust-lang/rust
@@ -10,24 +8,36 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to Github Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: write
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
-      - name: Branch name
-        id: branch_name
-        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # - name: Branch name
+      #   id: branch_name
+      #   run: echo "TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
       - name: Log in to Github Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test Building container image
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          build-args: |
+            TOOLCHAIN=${{ env.RUST_VERSION }}
+
       - name: Build container image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           push: true
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG TOOLCHAIN=stable
 # - https://www.openssl.org/source/
 #
 # ALSO UPDATE hooks/build!
-ARG OPENSSL_VERSION=1.1.1m
+ARG OPENSSL_VERSION=3.2.1
 
 # Versions for other dependencies. Here are the places to check for new
 # releases:
@@ -89,9 +89,7 @@ RUN echo "Building OpenSSL" && \
     ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/musl/include/asm && \
     ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic && \
     cd /tmp && \
-    short_version="$(echo "$OPENSSL_VERSION" | sed s'/[a-z]$//' )" && \
-    curl -fLO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" || \
-    curl -fLO "https://www.openssl.org/source/old/$short_version/openssl-$OPENSSL_VERSION.tar.gz" && \
+    curl -fLO "https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz" && \
     tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
     env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 && \
     env C_INCLUDE_PATH=/usr/local/musl/include/ make depend && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,11 @@ ARG OPENSSL_VERSION=1.1.1m
 #
 # We're stuck on PostgreSQL 11 until we figure out
 # https://github.com/emk/rust-musl-builder/issues.
-ARG CARGO_ABOUT_VERSION=0.4.4
-ARG CARGO_DENY_VERSION=0.11.1
-ARG ZLIB_VERSION=1.3
-ARG POSTGRESQL_VERSION=11.11
-ARG PROTOBUF_VERSION=21.1
+ARG CARGO_ABOUT_VERSION=0.6.0
+ARG CARGO_DENY_VERSION=0.14.16
+ARG ZLIB_VERSION=1.3.1
+ARG POSTGRESQL_VERSION=14.11
+ARG PROTOBUF_VERSION=25.2
 
 # Make sure we have basic dev tools for building C libraries.  Our goal here is
 # to support the musl-libc builds and Cargo builds needed for a large selection

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Use Ubuntu 18.04 LTS as our base image.
 FROM ubuntu:22.04
 
-# The Rust toolchain to use when building our image.  Set by `hooks/build`.
-ARG TOOLCHAIN=stable
-
 # The OpenSSL version to use. Here is the place to check for new releases:
 #
 # - https://www.openssl.org/source/
@@ -133,6 +130,9 @@ RUN git config --global credential.https://github.com.helper ghtoken
 ENV RUSTUP_HOME=/opt/rust/rustup \
     PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     CARGO_HOME=/opt/rust/cargo
+
+# The Rust toolchain to use when building our image.  Set by `hooks/build`.
+ARG TOOLCHAIN=stable
 
 # Install our Rust toolchain and the `musl` target.  We patch the
 # command-line we pass to the installer so that it won't attempt to

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN echo "Building libpq" && \
     cd /tmp && \
     curl -fLO "https://ftp.postgresql.org/pub/source/v$POSTGRESQL_VERSION/postgresql-$POSTGRESQL_VERSION.tar.gz" && \
     tar xzf "postgresql-$POSTGRESQL_VERSION.tar.gz" && cd "postgresql-$POSTGRESQL_VERSION" && \
-    CC="musl-gcc -fPIE -pie" CPPFLAGS="-I/usr/local/musl/include -I/tmp/postgresql-$POSTGRESQL_VERSION/src/include" LDFLAGS="-L/usr/local/musl/lib -L/usr/local/musl/lib64" ./configure --with-openssl --without-readline --with-pgport=5432 --prefix=/usr/local/musl --host=x86_64-unknown-linux-musl && \
+    CC=musl-gcc CPPFLAGS="-I/usr/local/musl/include" LDFLAGS="-L/usr/local/musl/lib -L/usr/local/musl/lib64" ./configure --with-openssl --without-readline --prefix=/usr/local/musl && \
     cd src/interfaces/libpq && make all-static-lib && make install-lib-static && \
     cd ../../bin/pg_config && make && make install && \
     cd "/tmp/postgresql-$POSTGRESQL_VERSION/src" && \
@@ -170,11 +170,7 @@ ADD cargo-config.toml /opt/rust/cargo/config
 # Set up our environment variables so that we cross-compile using musl-libc by
 # default.
 ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=/usr/local/musl/ \
-    X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_INCLUDE_DIR=/usr/local/musl/include/ \
-    X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_LIB_DIR=/usr/local/musl/lib64/ \
     X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_STATIC=1 \
-    DEP_OPENSSL_INCLUDE=/usr/local/musl/include/ \
-    OPENSSL_STATIC=1 \
     PQ_LIB_STATIC_X86_64_UNKNOWN_LINUX_MUSL=1 \
     PG_CONFIG_X86_64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
     PKG_CONFIG_ALLOW_CROSS=true \

--- a/hooks/build
+++ b/hooks/build
@@ -12,7 +12,7 @@ set -euo pipefail
 # we do offer the option of falling back to 1.0.
 #
 # Find the latest version at https://www.openssl.org/source/
-OPENSSL_VERSION=1.1.1i
+OPENSSL_VERSION=3.2.1
 
 # Pick an appropriate Docker tag
 case "$DOCKER_TAG" in


### PR DESCRIPTION
# Changed

- It checks `docker build` on GitHub Action when codes are pushed to this repository.
- GitHub Action libraries are updated
- docker building is cached in GitHub Action
- All libraries is updated
    - OpenSSL: 1.1.1m -> 3.2.1
    - Zlib: 1.3 -> 1.3.1
    - libpq: 11.11 -> 14.11
    - protoc: 21.1 -> 25.2
    - cargo about: 0.4.4 -> 0.6.0
    - cargo deny: 0.11.1 -> 0.14.16
- refactoring